### PR TITLE
🐛 fix: Remove clicking login by student button

### DIFF
--- a/fortytwo_auto_api.py
+++ b/fortytwo_auto_api.py
@@ -81,8 +81,10 @@ class fortytwo_auto_keys:
         """Handle fortytwo intra login
         Fill field login/password and click on login button
         """
+        """Removed because of new login page
         sign_in_button = self.browser.find_element(By.XPATH, "//a[@class='btn btn-login-student']")
         sign_in_button.click()
+        """
         login_field = self.browser.find_element(By.NAME, "username")
         password_field = self.browser.find_element(By.NAME, "password")
         login_field.clear()


### PR DESCRIPTION
# 문제 상황
- 이전 42 인트라 로그인 페이지에서 'login by student' 버튼이 사라지면서 코드가 작동하지 않는 문제가 있었습니다.

# 작업 내용
- 해당 버튼을 클릭하는 코드를 주석으로 처리하여 제거했습니다.